### PR TITLE
set keyname default to match variables.tf

### DIFF
--- a/ssh_keys/generate_key_pair.sh
+++ b/ssh_keys/generate_key_pair.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KEY_NAME=${1:?"key name is required as 1. parameter"}
+KEY_NAME=${1:-rtmo-key}
 EXISTING_KEY=$2
 KEY_PATH=.
 KEY=$KEY_PATH/$KEY_NAME


### PR DESCRIPTION
Probably better than #2

As this will generate `rtmo-key.pem` and `rtmo-key.pub` so the default values in [variables.tf](https://github.com/hashicorp/rtmo-terraform/blob/master/variables.tf#L2) are matching.
